### PR TITLE
feat: accommodate multiple streams from a single source coordinate

### DIFF
--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -23,7 +23,7 @@ contract SubscriptionModule {
 
     using CirclesLib for TypeDefinitions.FlowEdge[];
 
-    using CirclesLib for TypeDefinitions.Stream;
+    using CirclesLib for TypeDefinitions.Stream[];
 
     /*//////////////////////////////////////////////////////////////
                             STATE VARIABLES
@@ -71,7 +71,8 @@ contract SubscriptionModule {
         address[] calldata flowVertices,
         TypeDefinitions.FlowEdge[] calldata flow,
         TypeDefinitions.Stream[] calldata streams,
-        bytes calldata packedCoordinates
+        bytes calldata packedCoordinates,
+        uint256 sourceCoordinate
     )
         external
     {
@@ -83,11 +84,11 @@ contract SubscriptionModule {
         uint256 periods = (block.timestamp - sub.lastRedeemed) / sub.frequency;
         require(periods >= 1, Errors.NotRedeemable());
 
-        TypeDefinitions.Stream memory stream = streams[0];
-        require(streams.length == 1, Errors.SingleStreamOnly());
-        require(flowVertices[stream.sourceCoordinate] == sub.subscriber, Errors.InvalidSubscriber());
+        require(flowVertices[sourceCoordinate] == sub.subscriber, Errors.InvalidSubscriber());
 
-        require(stream.checkRecipients(sub.recipient, flowVertices, packedCoordinates), Errors.InvalidRecipient());
+        require(streams.checkSource(sourceCoordinate), Errors.InvalidStreamSource());
+
+        require(streams.checkRecipients(sub.recipient, flowVertices, packedCoordinates), Errors.InvalidRecipient());
 
         require(flow.extractAmount() == periods * sub.amount, Errors.InvalidAmount());
 

--- a/src/libs/CirclesLib.sol
+++ b/src/libs/CirclesLib.sol
@@ -21,13 +21,13 @@ library CirclesLib {
     }
 
     /// @notice Verify that every flow edge in the given stream routes to the specified recipient.
-    /// @param stream A Stream struct whose flow edge ids define how many edges to check.
+    /// @param streams A Stream struct whose flow edge ids define how many edges to check.
     /// @param recipient The address that each to index must match.
     /// @param flowVertices The list of all addresses (vertices) used to resolve each to index.
     /// @param coordinates Packed coordinates for this stream.
     /// @return success True if every extracted to address equals `recipient`, otherwise false.
     function checkRecipients(
-        TypeDefinitions.Stream memory stream,
+        TypeDefinitions.Stream[] calldata streams,
         address recipient,
         address[] calldata flowVertices,
         bytes calldata coordinates
@@ -36,13 +36,27 @@ library CirclesLib {
         pure
         returns (bool)
     {
+        TypeDefinitions.Stream memory stream = streams[streams.length - 1];
         uint256 edgeCount = stream.flowEdgeIds.length;
         for (uint256 i = 0; i < edgeCount; i++) {
             uint256 start = 6 * stream.flowEdgeIds[i] + 4;
             uint256 toIndex = slice(coordinates, start, start + 2);
             if (flowVertices[toIndex] != recipient) return false;
         }
+        return true;
+    }
 
+    function checkSource(
+        TypeDefinitions.Stream[] calldata streams,
+        uint256 sourceCoordinate
+    )
+        internal
+        pure
+        returns (bool success)
+    {
+        for (uint256 i; i < streams.length; ++i) {
+            if (streams[i].sourceCoordinate != sourceCoordinate) return false;
+        }
         return true;
     }
 

--- a/src/libs/Errors.sol
+++ b/src/libs/Errors.sol
@@ -16,6 +16,8 @@ library Errors {
 
     error InvalidSubscriber();
 
+    error InvalidStreamSource();
+
     error NotRedeemable();
 
     error SingleStreamOnly();


### PR DESCRIPTION
Previously, we only supported single stream flows via `operateFlowMatrix`. This PR introduces support for multiple streams from a single source coordinate, inspired by [this](https://github.com/aboutcircles/circles-contracts-v2/blob/6b259fc882852588ce4cc7a878993cfb80b90255/src/operators/SignedPathOperator.sol#L4) contract.