### PR TITLE
feat: multiple transfer paths with shared helpers

### DIFF
--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -161,6 +161,10 @@ contract SubscriptionModule {
         return (block.timestamp - subscription.lastRedeemed) / subscription.frequency * subscription.amount;
     }
 
+    function isTrustedRequired(bytes32 id) external view returns (bool) {
+        return subscriptions[safeFromId[id]][id].requiresTrust;
+    }
+
     /*//////////////////////////////////////////////////////////////
                     INTERNAL NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -142,7 +142,7 @@ contract SubscriptionModule {
         _unsubscribe(msg.sender, id);
     }
 
-    function unsubscribeMultiple(bytes32[] calldata _ids) external {
+    function unsubscribeMany(bytes32[] calldata _ids) external {
         for (uint256 i; i < _ids.length; ++i) {
             _unsubscribe(msg.sender, _ids[i]);
         }

--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -162,7 +162,7 @@ contract SubscriptionModule {
     }
 
     function isTrustedRequired(bytes32 id) external view returns (bool) {
-        return subscriptions[safeFromId[id]][id].requiresTrust;
+        return subscriptions[safeFromId[id]][id].requireTrusted;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/libs/Errors.sol
+++ b/src/libs/Errors.sol
@@ -21,4 +21,6 @@ library Errors {
     error NotRedeemable();
 
     error SingleStreamOnly();
+
+    error TrustedPathOnly();
 }

--- a/src/libs/Types.sol
+++ b/src/libs/Types.sol
@@ -7,4 +7,5 @@ struct Subscription {
     uint256 amount;
     uint256 lastRedeemed;
     uint256 frequency;
+    bool requireTrusted;
 }


### PR DESCRIPTION
Vendors can choose if they care what Circles tokens they are receiving from subscriptions. Scenarios:

- Vendor cares: set `requireTrusted==true`, redemptions can only go through `operateFlowMatrix` which enforces trust assumptions.
- Vendor does not care: set `requireTrusted==false`, redemptions can go through either `operateFlowMatrix` or `safeTransferFrom`.

Closes #6