### PR TITLE
fix: emitting struct in event just yields hash of data

### DIFF
--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -31,7 +31,7 @@ contract SubscriptionModule {
     //////////////////////////////////////////////////////////////*/
 
     string public constant NAME = "Subscription Module";
-    string public constant VERSION = "0.0.1";
+    string public constant VERSION = "0.1.0";
 
     address public constant HUB = 0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8;
 
@@ -59,9 +59,7 @@ contract SubscriptionModule {
         bytes32 indexed id,
         address indexed subscriber,
         address indexed recipient,
-        uint256 amount,
         uint256 lastRedeemed,
-        uint256 frequency,
         bool requireTrusted
     );
 

--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -126,7 +126,7 @@ contract SubscriptionModule {
             Errors.ExecutionFailed()
         );
 
-        emit Redeemed(id, safe, sub.recipient, sub.amount, sub.lastRedeemed, sub.frequency, sub.requireTrusted);
+        emit Redeemed(id, safe, sub.recipient, sub.lastRedeemed, sub.requireTrusted);
     }
 
     function redeemUntrusted(bytes32 id) external {
@@ -151,7 +151,7 @@ contract SubscriptionModule {
             Errors.ExecutionFailed()
         );
 
-        emit Redeemed(id, safe, sub.recipient, sub.amount, sub.lastRedeemed, sub.frequency, sub.requireTrusted);
+        emit Redeemed(id, safe, sub.recipient, sub.lastRedeemed, sub.requireTrusted);
     }
 
     function unsubscribe(bytes32 id) external {

--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -45,9 +45,25 @@ contract SubscriptionModule {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    event SubscriptionCreated(bytes32 indexed id, Subscription indexed subscription);
+    event SubscriptionCreated(
+        bytes32 indexed id,
+        address indexed subscriber,
+        address indexed recipient,
+        uint256 amount,
+        uint256 lastRedeemed,
+        uint256 frequency,
+        bool requireTrusted
+    );
 
-    event Redeemed(bytes32 indexed id, Subscription indexed subscription);
+    event Redeemed(
+        bytes32 indexed id,
+        address indexed subscriber,
+        address indexed recipient,
+        uint256 amount,
+        uint256 lastRedeemed,
+        uint256 frequency,
+        bool requireTrusted
+    );
 
     /*//////////////////////////////////////////////////////////////
                    USER-FACING NON-CONSTANT FUNCTIONS
@@ -73,7 +89,9 @@ contract SubscriptionModule {
         });
         id = sub.compute();
         _subscribe(msg.sender, id, sub);
-        emit SubscriptionCreated(id, sub);
+        emit SubscriptionCreated(
+            id, msg.sender, recipient, amount, block.timestamp - frequency, frequency, requireTrusted
+        );
     }
 
     function redeem(
@@ -110,7 +128,7 @@ contract SubscriptionModule {
             Errors.ExecutionFailed()
         );
 
-        emit Redeemed(id, sub);
+        emit Redeemed(id, safe, sub.recipient, sub.amount, sub.lastRedeemed, sub.frequency, sub.requireTrusted);
     }
 
     function redeemUntrusted(bytes32 id) external {
@@ -135,7 +153,7 @@ contract SubscriptionModule {
             Errors.ExecutionFailed()
         );
 
-        emit Redeemed(id, sub);
+        emit Redeemed(id, safe, sub.recipient, sub.amount, sub.lastRedeemed, sub.frequency, sub.requireTrusted);
     }
 
     function unsubscribe(bytes32 id) external {


### PR DESCRIPTION
Added all `Subscription` fields to both events. I don't think it is necessary to include all parameters in the `Redeem` event, however, kept this as is for now. 

We should decide what fields to remove, I propose removing `amount` and `frequency`. Rationale:
- shouldn't be changeable after subscription creation, whereas we may add functionality for the subscription recipient to change: the recipient address & whether they require a trusted path. 