### PR TITLE
feat: current subscription recipient can transfer rights to a new address

### DIFF
--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -63,6 +63,8 @@ contract SubscriptionModule {
         bool requireTrusted
     );
 
+    event RecipientUpdated(bytes32 indexed id, address indexed oldRecipient, address indexed newRecipient);
+
     /*//////////////////////////////////////////////////////////////
                    USER-FACING NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -162,6 +164,14 @@ contract SubscriptionModule {
         for (uint256 i; i < _ids.length; ++i) {
             _unsubscribe(msg.sender, _ids[i]);
         }
+    }
+
+    function updateRecipient(bytes32 id, address newRecipient) external {
+        address safe = safeFromId[id];
+        Subscription storage sub = _subscriptions[safe][id];
+        require(sub.recipient == msg.sender, Errors.OnlyRecipient());
+        sub.recipient = newRecipient;
+        emit RecipientUpdated(id, msg.sender, newRecipient);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/SubscriptionModule.sol
+++ b/src/SubscriptionModule.sol
@@ -168,8 +168,8 @@ contract SubscriptionModule {
                      USER-FACING CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function getSubscription(address safe, bytes32 id) external view returns (Subscription memory) {
-        return _subscriptions[safe][id];
+    function getSubscription(bytes32 id) external view returns (Subscription memory) {
+        return _subscriptions[safeFromId[id]][id];
     }
 
     function getSubscriptionIds(address safe) external view returns (bytes32[] memory) {

--- a/src/libs/Errors.sol
+++ b/src/libs/Errors.sol
@@ -23,4 +23,6 @@ library Errors {
     error SingleStreamOnly();
 
     error TrustedPathOnly();
+
+    error OnlyRecipient();
 }

--- a/test/unit/fuzz/subscribe/subscribe.t.sol
+++ b/test/unit/fuzz/subscribe/subscribe.t.sol
@@ -44,7 +44,7 @@ contract Subscribe_Unit_Fuzz_Test is Base_Test {
         vm.assume(id != bytes32(ZERO_SENTINEL));
         module.exposed__subscribe(subscriber, id, subscription);
 
-        assertEq(module.getSubscription(subscriber, id), subscription);
+        assertEq(module.getSubscription(id), subscription);
         assertEq(module.safeFromId(id), subscriber);
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = id;
@@ -102,7 +102,7 @@ contract Subscribe_Unit_Fuzz_Test is Base_Test {
 
         bytes32 id = module.subscribe(recipient, amount, frequency, requireTrusted);
 
-        assertEq(module.getSubscription(users.subscriber, id), sub);
+        assertEq(module.getSubscription(id), sub);
         assertEq(module.safeFromId(id), users.subscriber);
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = id;

--- a/test/unit/fuzz/subscribe/subscribe.t.sol
+++ b/test/unit/fuzz/subscribe/subscribe.t.sol
@@ -33,7 +33,7 @@ contract Subscribe_Unit_Fuzz_Test is Base_Test {
         module.exposed__subscribe(subscriber, id, subscription);
     }
 
-    function testFuzz_Subscribe(
+    function testFuzz_Subscribe_Internal(
         address subscriber,
         bytes32 id,
         Subscription memory subscription

--- a/test/unit/fuzz/unsubscribe/unsubscribe.t.sol
+++ b/test/unit/fuzz/unsubscribe/unsubscribe.t.sol
@@ -29,7 +29,7 @@ contract Subscribe_Unit_Fuzz_Test is Base_Test {
 
         module.exposed__unsubscribe(subscriber, id);
 
-        assertEq(module.getSubscription(subscriber, id), defaults.subscriptionEmpty());
+        assertEq(module.getSubscription(id), defaults.subscriptionEmpty());
         assertEq(module.safeFromId(id), address(0));
         bytes32[] memory ids;
         assertEq(module.getSubscriptionIds(subscriber), ids);

--- a/test/unit/fuzz/update-recipient/updateRecipient.t.sol
+++ b/test/unit/fuzz/update-recipient/updateRecipient.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.28 <0.9.0;
+
+import { Base_Test } from "test/Base.t.sol";
+
+import { SubscriptionModule } from "src/SubscriptionModule.sol";
+import { SubscriptionLib } from "src/libs/SubscriptionLib.sol";
+import { Errors } from "src/libs/Errors.sol";
+import { Subscription } from "src/libs/Types.sol";
+
+contract UpdateRecipient_Unit_Fuzz_Test is Base_Test {
+    bytes32 internal id;
+
+    function setUp() public override {
+        Base_Test.setUp();
+
+        id = module.subscribe(users.recipient, defaults.SUBSCRIPTION_AMOUNT(), defaults.SUBSCRIPTION_FREQUENCY(), true);
+    }
+
+    function testFuzz_ShouldRevert_SubscriptionDoesNotExist() external {
+        module.updateRecipient(keccak256(abi.encode("FAKE_SUBSCRIPTION_ID")), address(0x1));
+    }
+
+    function testFuzz_ShouldRevert_CallerNotRecipient(address caller) external {
+        vm.assume(caller != users.recipient);
+        resetPrank({ msgSender: caller });
+        vm.expectRevert(Errors.OnlyRecipient.selector);
+        module.updateRecipient(id, address(0));
+    }
+
+    function testFuzz_UpdateRecipient(address newRecipient) external whenCallerRecipient {
+        module.updateRecipient(id, newRecipient);
+        assertEq(module.getSubscription(id).recipient, newRecipient);
+    }
+}

--- a/test/unit/fuzz/update-recipient/updateRecipient.t.sol
+++ b/test/unit/fuzz/update-recipient/updateRecipient.t.sol
@@ -18,6 +18,7 @@ contract UpdateRecipient_Unit_Fuzz_Test is Base_Test {
     }
 
     function testFuzz_ShouldRevert_SubscriptionDoesNotExist() external {
+        vm.expectRevert(Errors.OnlyRecipient.selector);
         module.updateRecipient(keccak256(abi.encode("FAKE_SUBSCRIPTION_ID")), address(0x1));
     }
 

--- a/test/unit/fuzz/update-recipient/updateRecipient.tree
+++ b/test/unit/fuzz/update-recipient/updateRecipient.tree
@@ -1,0 +1,6 @@
+updateRecipient.t.sol
+├── given the caller is not the subscription recipient
+│   └── it should revert
+└── given the caller is subscription recipient
+    ├── it should update the recipient
+    └── it should emit a {RecipientUpdated} event

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -4,4 +4,5 @@ pragma solidity >=0.8.28;
 abstract contract Constants {
     uint256 internal constant JULY_1_2024 = 1_719_792_000;
     uint256 internal constant ZERO_SENTINEL = 0xfbb67fda52d4bfb8bf;
+    uint256 internal constant SECONDS_PER_YEAR = 31_536_000;
 }

--- a/test/utils/Modifiers.sol
+++ b/test/utils/Modifiers.sol
@@ -39,4 +39,9 @@ abstract contract Modifiers is Constants, Utils {
         resetPrank({ msgSender: users.subscriber });
         _;
     }
+
+    modifier whenCallerRecipient() {
+        resetPrank({ msgSender: users.recipient });
+        _;
+    }
 }


### PR DESCRIPTION
Adds a new `updateRecipient` function that allows current recipient to transfer subscription rights to a different address. On success, emits a `RecipientUpdated` event.