### PR TITLE
Remove unused local varaiables

### DIFF
--- a/test/fork/Module.t.sol
+++ b/test/fork/Module.t.sol
@@ -24,13 +24,8 @@ contract Module_Fork_Test is Fork_Test {
 
         _enableModule();
 
-        (
-            TypeDefinitions.FlowEdge[] memory flowEdges,
-            address[] memory flowVertices,
-            bytes memory packedCoordinates,
-            uint256 sourceCoordinate,
-            TypeDefinitions.Stream[] memory streams
-        ) = _toTypeFlowInfo(info);
+        (TypeDefinitions.FlowEdge[] memory flowEdges,,,, TypeDefinitions.Stream[] memory streams) =
+            _toTypeFlowInfo(info);
 
         resetPrank({ msgSender: FROM });
         bytes32 id = module.subscribe(info.to, info.value, 3600, true);


### PR DESCRIPTION
Just wanted to eliminate these compile time warnings:

```
➜  subi-contracts git:(unused-local-vars) forge build
[⠊] Compiling...
[⠘] Compiling 8 files with Solc 0.8.28
[⠃] Solc 0.8.28 finished in 1.78s
Compiler run successful with warnings:
Warning (2072): Unused local variable.
  --> test/fork/Module.t.sol:29:13:
   |
29 |             address[] memory flowVertices,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (2072): Unused local variable.
  --> test/fork/Module.t.sol:30:13:
   |
30 |             bytes memory packedCoordinates,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (2072): Unused local variable.
  --> test/fork/Module.t.sol:31:13:
   |
31 |             uint256 sourceCoordinate,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^
```